### PR TITLE
fix:change registry from catenax-ng to docker.io

### DIFF
--- a/charts/discoveryfinder/values.yaml
+++ b/charts/discoveryfinder/values.yaml
@@ -21,8 +21,8 @@ enablePostgres: true
 
 discoveryfinder:
   image:
-    registry: ghcr.io/catenax-ng
-    repository: sldt-discovery-finder
+    registry: docker.io
+    repository: tractusx/sldt-discovery-finder
     version: ""
     imagePullPolicy: IfNotPresent
   replicaCount: 1


### PR DESCRIPTION
## Description
- change registry name from catenax-ng to docker.io 