### PR TITLE
fix:KICS Privilege Escalation Allowed violation

### DIFF
--- a/charts/discoveryfinder/templates/deployment.yaml
+++ b/charts/discoveryfinder/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
           {{- end }}
           ports:
             - containerPort: {{ .Values.discoveryfinder.containerPort }}
+#         Containers should not run with allowPrivilegeEscalation in order to prevent them from gaining more privileges than their parent process
+#         Refer Set the security context for a Pod section here - https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+          securityContext:
+            allowPrivilegeEscalation: false
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness

--- a/charts/discoveryfinder/templates/deployment.yaml
+++ b/charts/discoveryfinder/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: {{ $deployment_name }}
     spec:
+      securityContext:
+        runAsUser: 100
       containers:
         - name: {{ $deployment_name }}
           image: {{ .Values.discoveryfinder.image.registry }}/{{ .Values.discoveryfinder.image.repository }}:{{ .Values.discoveryfinder.image.version | default .Chart.AppVersion }}
@@ -27,6 +29,7 @@ spec:
 #         Containers should not run with allowPrivilegeEscalation in order to prevent them from gaining more privileges than their parent process
 #         Refer Set the security context for a Pod section here - https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
           securityContext:
+            runAsUser: 100
             allowPrivilegeEscalation: false
           livenessProbe:
             httpGet:


### PR DESCRIPTION
## Description

Fixes
- KICS Privilege Escalation Allowed violation fix - Containers should not run with allowPrivilegeEscalation in order to prevent them from gaining more privileges than their parent process. Please refer Refer Set the security context for a Pod section for more information - https://kubernetes.io/docs/tasks/configure-pod-container/security-context/