### PR TITLE
fix:kics exclude open api yaml file

### DIFF
--- a/.kicsignore
+++ b/.kicsignore
@@ -1,1 +1,0 @@
-backend/src/main/resources/static/discovery-finder-openapi.yaml

--- a/.kicsignore
+++ b/.kicsignore
@@ -1,0 +1,1 @@
+backend/src/main/resources/static/discovery-finder-openapi.yaml

--- a/backend/src/main/resources/static/discovery-finder-openapi.yaml
+++ b/backend/src/main/resources/static/discovery-finder-openapi.yaml
@@ -1,3 +1,5 @@
+---
+# kics-scan ignore-block
 ###############################################################
 # Copyright (c) 2021-2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
@@ -17,8 +19,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
----
-# kics-scan ignore-block
 openapi: 3.0.3
 info:
   title: Discovery Finder

--- a/backend/src/main/resources/static/discovery-finder-openapi.yaml
+++ b/backend/src/main/resources/static/discovery-finder-openapi.yaml
@@ -17,7 +17,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
-
+---
+# kics-scan ignore-block
 openapi: 3.0.3
 info:
   title: Discovery Finder

--- a/charts/discoveryfinder/templates/deployment.yaml
+++ b/charts/discoveryfinder/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
           {{- end }}
           ports:
             - containerPort: {{ .Values.discoveryfinder.containerPort }}
+#         Containers should not run with allowPrivilegeEscalation in order to prevent them from gaining more privileges than their parent process
+#         Refer Set the security context for a Pod section here - https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+          securityContext:
+            allowPrivilegeEscalation: false
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness

--- a/charts/discoveryfinder/templates/deployment.yaml
+++ b/charts/discoveryfinder/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: {{ $deployment_name }}
     spec:
+      securityContext:
+        runAsUser: 100
       containers:
         - name: {{ $deployment_name }}
           image: {{ .Values.discoveryfinder.image.registry }}/{{ .Values.discoveryfinder.image.repository }}:{{ .Values.discoveryfinder.image.version | default .Chart.AppVersion }}
@@ -27,6 +29,7 @@ spec:
 #         Containers should not run with allowPrivilegeEscalation in order to prevent them from gaining more privileges than their parent process
 #         Refer Set the security context for a Pod section here - https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
           securityContext:
+            runAsUser: 100
             allowPrivilegeEscalation: false
           livenessProbe:
             httpGet:


### PR DESCRIPTION
## Description

Fixes # (issuenumber from PR destination repo)
- Exclude open api yaml file from KICS scanning .Please refer details [here](https://docs.kics.io/latest/running-kics/#:~:text=To%20use%20this%20feature%20you,rest%20of%20the%20file...)
