### PR TITLE
Bug: Remove unnecessary build image step

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -79,9 +79,6 @@ jobs:
       - name: Build JAR
         run: mvn clean package
         
-      - name: Build Image
-        run: docker build -t discovery-finder -f ./backend/Dockerfile .
-        
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
## Description
Removing the unnecessary build image step from trivy scan. since we test the latest image from docker hub, we don't need to build the current code.