### PR TITLE
fix: add missing copyright header to tractusx metadata file

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,3 +1,21 @@
+###############################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
 product: "Discovery Finder"
 leadingRepository: "https://github.com/eclipse-tractusx/sldt-discovery-finder"
 repositories:


### PR DESCRIPTION
PR to add missing copyrigh header to .tractusx metadata file. As per [TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02/) metadata files should also have a header.

Updates https://github.com/eclipse-tractusx/sldt-discovery-finder/issues/64
CC: @agg3fe 