### PR TITLE
Fix:Update upload artifact version to v4

### DIFF
--- a/.github/workflows/discoveryfinder-e2e-test.yml
+++ b/.github/workflows/discoveryfinder-e2e-test.yml
@@ -70,7 +70,7 @@ jobs:
           AUTH_SERVER_TOKEN_URL: ${{ inputs.tokenUrl }}
           DISCOVERYFINDER_API_URL: ${{ inputs.discoveryFinderUrl }}
       - name: Upload test report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: discoveryfinder-e2e-test-report

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gitleaks-report
       - name: Upload SARIF report

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -38,7 +38,7 @@ jobs:
           gitleaks detect -f sarif -r ./gitleaks-report-discovery-finder.sarif --exit-code 0
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gitleaks-report
           path: ./gitleaks-report-discovery-finder.sarif


### PR DESCRIPTION


## Description
Update upload artifact version to v4. Previous version v3 is no more supported.
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
