### PR TITLE
Fix: fixed CVE json smart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1
+### Added
+### fixed
+- fixed cve net.minidev:json-smart CVE-2024-57699
+
 ## 0.6.0
 ### Added
 ### fixed

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -34,8 +34,6 @@ maven/mavencentral/javax.activation/javax.activation-api/1.2.0, (CDDL-1.1 OR GPL
 maven/mavencentral/javax.xml.bind/jaxb-api/2.3.1, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ16911
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.15.10, Apache-2.0, approved, #16009
 maven/mavencentral/net.bytebuddy/byte-buddy/1.15.10, Apache-2.0 AND BSD-3-Clause, approved, #16008
-maven/mavencentral/net.minidev/accessors-smart/2.5.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/net.minidev/json-smart/2.5.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.0, BSD-3-Clause, approved, #10767
 maven/mavencentral/org.apache.commons/commons-collections4/4.4, Apache-2.0, approved, #17660
 maven/mavencentral/org.apache.commons/commons-lang3/3.17.0, Apache-2.0, approved, #16044
@@ -63,7 +61,6 @@ maven/mavencentral/org.mockito/mockito-core/5.14.2, MIT AND (Apache-2.0 AND MIT)
 maven/mavencentral/org.mockito/mockito-junit-jupiter/5.14.2, MIT, approved, #16376
 maven/mavencentral/org.openapitools/jackson-databind-nullable/0.2.5, Apache-2.0, approved, #3294
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713
-maven/mavencentral/org.ow2.asm/asm/9.6, BSD-3-Clause, approved, #10776
 maven/mavencentral/org.postgresql/postgresql/42.7.2, BSD-2-Clause AND Apache-2.0, approved, #11681
 maven/mavencentral/org.projectlombok/lombok/1.18.34, MIT, approved, #15192
 maven/mavencentral/org.skyscreamer/jsonassert/1.5.3, Apache-2.0, approved, clearlydefined

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,12 @@
          </exclusions>
       </dependency>
       <dependency>
+         <groupId>net.minidev</groupId>
+         <artifactId>json-smart</artifactId>
+         <version>2.5.2</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.springframework.boot</groupId>
          <artifactId>spring-boot-starter-data-jpa</artifactId>
          <version>${spring.boot.version}</version>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
fixed cve net.minidev:json-smart CVE-2024-57699
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
