### PR TITLE
fix(chart): passthrough tls secret and allow non-prefix paths

### DIFF
--- a/charts/discoveryfinder/Chart.yaml
+++ b/charts/discoveryfinder/Chart.yaml
@@ -23,7 +23,7 @@ home: https://eclipse-tractusx.github.io/
 sources:
   - https://github.com/eclipse-tractusx/sldt-discovery-finder
 type: application
-version: 0.5.1
+version: 0.6.0
 appVersion: 0.6.1
 
 dependencies:

--- a/charts/discoveryfinder/README.md
+++ b/charts/discoveryfinder/README.md
@@ -1,76 +1,115 @@
 # discoveryfinder
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
 
-**Tractus-X Discovery Finder Helm Chart** <br/>
-This chart installs the Discovery Finder and its direct dependencies.
+Tractus-X Discovery Finder Helm Chart
+
+**Homepage:** <https://eclipse-tractusx.github.io/>
+
+## Source Code
+
+* <https://github.com/eclipse-tractusx/sldt-discovery-finder>
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 12.2.3 |
+| https://charts.bitnami.com/bitnami | postgresql | 12.12.10 |
 
 ## Prerequisites
+
 - Kubernetes 1.19+
 - Helm 3.2.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Install
+
+To install the chart with the release name `discoveryfinder`:
+
+```shell
+helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+helm install discoveryfinder tractusx-dev/discoveryfinder
 ```
-helm dep up charts/discoveryfinder
-kubectl create namespace discovery
-helm install discoveryfinder -n discovery charts/discoveryfinder
+
+To install the helm chart into your cluster with your values:
+
+```shell
+helm install -f your-values.yaml discoveryfinder tractusx-dev/discoveryfinder
+```
+
+To use the helm chart as a dependency:
+
+```yaml
+dependencies:
+  - name: discoveryfinder
+    repository: https://eclipse-tractusx.github.io/charts/dev
+    version: YOUR_VERSION
+```
+
+To install the local version in the namespace _semantics_:
+
+```shell
+
+helm dependency update .
+
+helm install discoveryfinder -n semantics . --create-namespace
 ```
 
 ## Values
 
 | Key | Type | Default | Description |
-|-----|------|-------|-------------|
-| discoveryfinder.authentication | bool | `true` |  |
+|-----|------|---------|-------------|
+| discoveryfinder.authentication | bool | `true` | If 'authentication' is set to false, no OAuth authentication is enforced |
 | discoveryfinder.containerPort | int | `4243` |  |
 | discoveryfinder.dataSource.driverClassName | string | `"org.postgresql.Driver"` |  |
-| discoveryfinder.dataSource.password | string | `"password"` |  |
+| discoveryfinder.dataSource.password | string | `nil` |  |
 | discoveryfinder.dataSource.sqlInitPlatform | string | `"pg"` |  |
-| discoveryfinder.dataSource.url | string | `"jdbc:postgresql://database:5432"` |  |
-| discoveryfinder.dataSource.user | string | `"user"` |  |
+| discoveryfinder.dataSource.url | string | `"jdbc:postgresql://database:5432"` | The url, user, and password parameter will be ignored if 'enablePostgres' is set to true. In that case the postgresql auth parameters are used. |
+| discoveryfinder.dataSource.user | string | `nil` |  |
 | discoveryfinder.host | string | `"localhost"` |  |
 | discoveryfinder.idp.issuerUri | string | `"https://idp-url"` |  |
 | discoveryfinder.idp.publicClientId | string | `"idpClientID"` |  |
 | discoveryfinder.image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | discoveryfinder.image.registry | string | `"docker.io"` |  |
 | discoveryfinder.image.repository | string | `"tractusx/sldt-discovery-finder"` |  |
-| discoveryfinder.ingress.annotations."cert-manager.io/cluster-issuer" | string | `"selfsigned-cluster-issuer"` |  |
-| discoveryfinder.ingress.annotations."nginx.ingress.kubernetes.io/cors-allow-credentials" | string | `"true"` |  |
-| discoveryfinder.ingress.annotations."nginx.ingress.kubernetes.io/enable-cors" | string | `"true"` |  |
-| discoveryfinder.ingress.annotations."nginx.ingress.kubernetes.io/rewrite-target" | string | `"/$2"` |  |
-| discoveryfinder.ingress.annotations."nginx.ingress.kubernetes.io/use-regex" | string | `"true"` |  |
-| discoveryfinder.ingress.annotations."nginx.ingress.kubernetes.io/x-forwarded-prefix" | string | `"/discoveryfinder"` |  |
+| discoveryfinder.ingress.annotations | object | `{}` |  |
 | discoveryfinder.ingress.className | string | `"nginx"` |  |
-| discoveryfinder.ingress.enabled | bool | `false` |  |
-| discoveryfinder.ingress.tls | bool | `false` |  |
-| discoveryfinder.ingress.urlPrefix | string | `"/discoveryfinder"` |  |
-| discoveryfinder.properties.discoveryfinder | string | `nil` |  |
+| discoveryfinder.ingress.enabled | bool | `false` | enable ingress, default false |
+| discoveryfinder.ingress.rules | list | `[]` | specify rules on your own, if the pathType Prefix + Regex runs into issues with your ClusterIssuer has a "strict-validate-path-type" check. -host.http.paths[0].path must at least be set. Then pathType "ImplementationSpecific" is used with common service name and port. Multiple paths may be specified |
+| discoveryfinder.ingress.tls.enabled | bool | `false` | enable tls, default false |
+| discoveryfinder.ingress.tls.secretName | string | `"discoveryfinder-certificate-secret"` | reuse secret in namespace with given name, default "discoveryfinder-certificate-secret" |
+| discoveryfinder.ingress.urlPrefix | string | `"/discoveryfinder"` | use a urlPrefix to define a path of pathType "Prefix" with regex. Result is a path "/discoveryfinder(/|$)(.*)" |
+| discoveryfinder.livenessProbe.failureThreshold | int | `3` |  |
+| discoveryfinder.livenessProbe.initialDelaySeconds | int | `100` |  |
+| discoveryfinder.livenessProbe.periodSeconds | int | `3` |  |
+| discoveryfinder.properties | object | `{"discoveryfinder":null}` | If initial endpoints need to be created when the application starts, enable the initialEndpoints block and add initialEndpoints. Type and endpointAddress is required is enabled. |
+| discoveryfinder.readinessProbe.failureThreshold | int | `3` |  |
+| discoveryfinder.readinessProbe.initialDelaySeconds | int | `100` |  |
+| discoveryfinder.readinessProbe.periodSeconds | int | `3` |  |
 | discoveryfinder.replicaCount | int | `1` |  |
+| discoveryfinder.resources.limits.cpu | string | `"750m"` |  |
 | discoveryfinder.resources.limits.memory | string | `"1024Mi"` |  |
-| discoveryfinder.resources.requests.memory | string | `"512Mi"` |  |
+| discoveryfinder.resources.requests.cpu | string | `"250m"` |  |
+| discoveryfinder.resources.requests.memory | string | `"1024Mi"` |  |
 | discoveryfinder.service.port | int | `8080` |  |
 | discoveryfinder.service.type | string | `"ClusterIP"` |  |
 | enablePostgres | bool | `true` |  |
-| discoveryfinder.livenessProbe.initialDelaySeconds                        | int    | `100`                                                                                                                                                        |  |
-| discoveryfinder.livenessProbe.failureThreshold                        | int    | `3`                                                                                                                                                          |  |
-| discoveryfinder.livenessProbe.periodSeconds                        | int    | `3`                                                                                                                                                          |  |
-| discoveryfinder.readinessProbe.initialDelaySeconds                        | int    | `100`                                                                                                                                                        |  |
-| discoveryfinder.readinessProbe.failureThreshold                        | int    | `3`                                                                                                                                                          |  |
-| discoveryfinder.readinessProbe.periodSeconds                        | int    | `3`                                                                                                                                                          |  |
+| fullnameOverride | string | `nil` |  |
+| nameOverride | string | `nil` |  |
 | postgresql.auth.database | string | `"discoveryfinder"` |  |
-| postgresql.auth.password | string | `` |  |
+| postgresql.auth.existingSecret | string | `"secret-discoveryfinder-postgres-init"` | Secret contains passwords for username postgres. |
+| postgresql.auth.password | string | `nil` |  |
 | postgresql.auth.username | string | `"catenax"` |  |
-| postgresql.auth.existingSecret | string | `"secret-discoveryfinder-postgres-init"` |  |
-
+| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` | workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts |
+| postgresql.image.tag | string | `"15.4.0-debian-11-r45"` | workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts |
 | postgresql.primary.persistence.enabled | bool | `true` |  |
 | postgresql.primary.persistence.size | string | `"50Gi"` |  |
 | postgresql.service.ports.postgresql | int | `5432` |  |
 
-----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/sldt-discovery-finder

--- a/charts/discoveryfinder/README.md.gotmpl
+++ b/charts/discoveryfinder/README.md.gotmpl
@@ -1,0 +1,66 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+- PV provisioner support in the underlying infrastructure
+
+## Install
+
+To install the chart with the release name `discoveryfinder`:
+
+```shell
+helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+helm install discoveryfinder tractusx-dev/discoveryfinder
+```
+
+To install the helm chart into your cluster with your values:
+
+```shell
+helm install -f your-values.yaml discoveryfinder tractusx-dev/discoveryfinder
+```
+
+To use the helm chart as a dependency:
+
+```yaml
+dependencies:
+  - name: discoveryfinder
+    repository: https://eclipse-tractusx.github.io/charts/dev
+    version: YOUR_VERSION
+```
+
+To install the local version in the namespace _semantics_:
+
+```shell
+
+helm dependency update .
+
+helm install discoveryfinder -n semantics . --create-namespace
+```
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}
+
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/sldt-discovery-finder

--- a/charts/discoveryfinder/templates/ingress.yaml
+++ b/charts/discoveryfinder/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.discoveryfinder.ingress.enabled }}
 # Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -28,12 +29,15 @@ metadata:
     {{- include "df.labels" . | nindent 4 }}
 spec:
   ingressClassName: {{ .Values.discoveryfinder.ingress.className }}
-  {{- if .Values.discoveryfinder.ingress.tls }}
+  {{- if .Values.discoveryfinder.ingress.tls.enabled }}
   tls:
     - hosts:
         - {{ .Values.discoveryfinder.host }}
-      secretName: discoveryfinder-certificate-secret
+      secretName: {{ .Values.discoveryfinder.ingress.tls.secretName | default "discoveryfinder-certificate-secret" }}
+  {{- else }}
+  tls: []  # Ensures tls is an empty list when not enabled
   {{- end }}
+  {{- if .Values.discoveryfinder.ingress.urlPrefix }}
   rules:
     - host: {{ .Values.discoveryfinder.host }}
       http:
@@ -45,4 +49,21 @@ spec:
                 name: {{ include "df.fullname" . }}
                 port:
                   number: {{ .Values.discoveryfinder.service.port }}
+  {{- else }}
+  rules:
+    {{- range .Values.discoveryfinder.ingress.rules }}
+    - host: {{ .host | default $.Values.discoveryfinder.host }}
+      http:
+        paths:
+          {{- range .http.paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
+            backend:
+              service:
+                name: {{ include "df.fullname" $ }}
+                port:
+                  number: {{ $.Values.discoveryfinder.service.port }}
+          {{- end }}
+    {{- end}}
+  {{- end}}
 {{- end }}

--- a/charts/discoveryfinder/values.yaml
+++ b/charts/discoveryfinder/values.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
 # Copyright (c) 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -28,10 +29,10 @@ discoveryfinder:
   replicaCount: 1
   containerPort: 4243
   host: localhost
-  ## If 'authentication' is set to false, no OAuth authentication is enforced
+  # -- If 'authentication' is set to false, no OAuth authentication is enforced
   authentication: true
-  ## If initial endpoints need to be created when the application starts, enable the initialEndpoints block and add initialEndpoints.
-  ## Type and endpointAddress is required is enabled.
+  # -- If initial endpoints need to be created when the application starts, enable the initialEndpoints block and add initialEndpoints.
+  # Type and endpointAddress is required is enabled.
   properties:
     discoveryfinder:
   #    initialEndpoints:
@@ -57,17 +58,44 @@ discoveryfinder:
   dataSource:
     driverClassName: org.postgresql.Driver
     sqlInitPlatform: pg
-    ## The url, user, and password parameter will be ignored if 'enablePostgres' is set to true.
-    ## In that case the postgresql auth parameters are used.
+    # -- The url, user, and password parameter will be ignored if 'enablePostgres' is set to true.
+    # In that case the postgresql auth parameters are used.
     url: jdbc:postgresql://database:5432
     user:
     password:
   ingress:
+    # -- enable ingress, default false
     enabled: false
-    tls: false
+    tls:
+      # -- enable tls, default false
+      enabled: false
+      # -- reuse secret in namespace with given name, default "discoveryfinder-certificate-secret"
+      secretName: discoveryfinder-certificate-secret
+    # -- use a urlPrefix to define a path of pathType "Prefix" with regex. Result is a path "/discoveryfinder(/|$)(.*)"
     urlPrefix: /discoveryfinder
+    # -- specify rules on your own, if the pathType Prefix + Regex runs into issues with your ClusterIssuer has a "strict-validate-path-type" check. -host.http.paths[0].path must at least be set. Then pathType "ImplementationSpecific" is used with common service name and port. Multiple paths may be specified
+    rules: []
+    # Minimum sample
+#      - host:
+#        http:
+#          paths:
+#            - path: /
+#              pathType:
+#              backend:
+#                service:
+#                  name:
+#                  port:
+#                    number:
+
     className: nginx
     annotations: {}
+      # Add annotations for the ingress, e.g.:
+      # cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+      # nginx.ingress.kubernetes.io/rewrite-target: /$2
+      # nginx.ingress.kubernetes.io/use-regex: "true"
+      # nginx.ingress.kubernetes.io/enable-cors: "true"
+      # nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+      # nginx.ingress.kubernetes.io/x-forwarded-prefix: /discoveryfinder
   resources:
     limits:
       cpu: 750m
@@ -77,6 +105,11 @@ discoveryfinder:
       memory: 1024Mi
 
 postgresql:
+  image:
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    repository: bitnamilegacy/postgresql
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    tag: 15.4.0-debian-11-r45
   primary:
     persistence:
       enabled: true


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

solves #198

Did the same as during [this dtr pr](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/pull/507)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
