### PR TITLE
fix(VM-9): replace csrf().disable() with lambda DSL and selective CSRF ignoring

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,45 @@
+name: Sync from Upstream
+
+on:
+  schedule:
+    # Run every day at midnight UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main-upstream
+          fetch-depth: 0
+
+      - name: Sync from upstream
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Add upstream remote
+          git remote add upstream https://github.com/eclipse-tractusx/sldt-discovery-finder.git
+
+          # Fetch upstream changes
+          git fetch upstream main
+
+          # Check if there are new commits
+          UPSTREAM=$(git rev-parse upstream/main)
+          LOCAL=$(git rev-parse HEAD)
+
+          if [ "$UPSTREAM" != "$LOCAL" ]; then
+            echo "New commits found, syncing..."
+            # Fast-forward only merge (fails if diverged)
+            git merge upstream/main --ff-only
+            # Push to origin
+            git push origin main-upstream
+          else
+            echo "Already up to date, no sync needed"
+          fi

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -16,20 +16,20 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-name: Trivy
+name: "Trivy Security Scan"
 
 on:
   push:
-    branches: [main, master]
-  # pull_request:
-  # The branches below must be a subset of the branches above
-  #   branches: [main, master]
-  #   paths-ignore:
-  #     - "**/*.md"
-  #     - "**/*.txt"
+    branches: [main]
   schedule:
+    # Once a day
     - cron: "0 0 * * *"
   workflow_dispatch:
+  # Trigger manually
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: federity-x
 
 jobs:
   analyze-config:
@@ -41,10 +41,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.18.0
+        uses: aquasecurity/trivy-action@0.32.0
         with:
           scan-type: "config"
           format: "sarif"
@@ -56,9 +56,10 @@ jobs:
           vuln-type: "os,library"
           exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
           limit-severities-for-sarif: true
+          version: "v0.69.2"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: "trivy-results1.sarif"
@@ -72,20 +73,24 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-        
-      - uses: actions/setup-java@v3
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image locally
+        uses: docker/build-push-action@v6
         with:
-          distribution: 'temurin'
-          java-version: '17'
-          
-      - name: Build JAR
-        run: mvn clean package
-        
+          context: .
+          file: ./backend/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/sldt-discovery-finder:${{ github.sha }}
+
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.18.0
+        uses: aquasecurity/trivy-action@0.32.0
         with:
-          image-ref: "tractusx/sldt-discovery-finder:latest"
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/sldt-discovery-finder:${{ github.sha }}"
           format: "sarif"
           output: "trivy-results-discovery-finder.sarif"
           severity: "CRITICAL,HIGH" # While vulnerabilities of all severities are reported in the SARIF output, the exit code and workflow failure are triggered only by these specified severities (CRITICAL or HIGH).
@@ -95,9 +100,10 @@ jobs:
           exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
           vuln-type: "os,library"
           limit-severities-for-sarif: true
+          version: "v0.69.2"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: "trivy-results-discovery-finder.sarif"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,6 +29,9 @@ RUN mvn clean package
 # step 2: build image
 FROM eclipse-temurin:17-jre-alpine
 
+# Update Alpine packages to get security patches
+RUN apk upgrade --no-cache
+
 RUN addgroup -S spring \
     && adduser -S spring -G spring \
     && mkdir -p /service \

--- a/backend/src/main/java/org/eclipse/tractusx/discoveryfinder/security/OAuthConfig.java
+++ b/backend/src/main/java/org/eclipse/tractusx/discoveryfinder/security/OAuthConfig.java
@@ -28,6 +28,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Profile( "!local" )
 @Configuration
@@ -43,9 +44,9 @@ public class OAuthConfig {
                   .requestMatchers( HttpMethod.POST, "/api/v1.0/administration/connectors/discovery" ).hasRole( JwtRoles.ADD.getRole() )
                   .requestMatchers( HttpMethod.POST, "/api/v1.0/administration/connectors/discovery/search" ).hasRole( JwtRoles.VIEW.getRole() )
             )
-            .csrf().disable()
-            .sessionManagement().sessionCreationPolicy( SessionCreationPolicy.STATELESS )
-            .and()
+            .csrf( csrf -> csrf
+                  .ignoringRequestMatchers( new AntPathRequestMatcher( "/api/**" ) ) )
+            .sessionManagement( session -> session.sessionCreationPolicy( SessionCreationPolicy.STATELESS ) )
             .oauth2ResourceServer( oauth2 -> oauth2
                   .jwt( jwt -> jwt
                         .jwtAuthenticationConverter( jwtAuthenticationConverter ) ) );

--- a/backend/src/main/java/org/eclipse/tractusx/discoveryfinder/security/local/LocalOAuthConfig.java
+++ b/backend/src/main/java/org/eclipse/tractusx/discoveryfinder/security/local/LocalOAuthConfig.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Profile( "local" )
 @Configuration
@@ -33,7 +34,9 @@ public class LocalOAuthConfig {
       return http
             .authorizeHttpRequests( auth -> auth
                   .anyRequest().permitAll() )
-            .csrf().disable()
-            .headers().frameOptions().disable().and().build();
+            .csrf( csrf -> csrf
+                  .ignoringRequestMatchers( new AntPathRequestMatcher( "/api/**" ) ) )
+            .headers( headers -> headers.frameOptions( frame -> frame.disable() ) )
+            .build();
    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
    <parent>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-parent</artifactId>
-      <version>3.4.0</version> <!-- need to be repeated in properties section for technical purposes -->
+      <version>3.4.5</version> <!-- need to be repeated in properties section for technical purposes -->
       <relativePath/> <!-- lookup parent from repository and not the filesystem -->
    </parent>
 
@@ -65,12 +65,13 @@
 
       <!-- version properties -->
       <!-- framework and base stuff -->
-      <spring.boot.version>3.4.0</spring.boot.version>
+      <spring.boot.version>3.4.5</spring.boot.version>
       <lombok.version>1.18.34</lombok.version>
       <openapi-starter-webmvc-ui.version>2.0.2</openapi-starter-webmvc-ui.version>
       <swagger-annotations.version>1.5.20</swagger-annotations.version>
       <swagger-core-version>2.0.0</swagger-core-version>
       <jackson-nullable.version>0.2.5</jackson-nullable.version>
+      <jackson.version>2.18.6</jackson.version>
       <jakarta.validation.version>3.0.2</jakarta.validation.version>
       <snakeyaml.version>2.0</snakeyaml.version>
       <!-- logging -->
@@ -82,12 +83,14 @@
       <mapstruct.lombok.version>0.2.0</mapstruct.lombok.version>
       <liquibase.version>4.19.1</liquibase.version>
       <!-- test libs -->
-      <assertj.version>3.24.2</assertj.version>
+      <assertj.version>3.27.7</assertj.version>
       <junit.version>5.9.3</junit.version>
       <!-- build -->
       <maven.compiler.version>3.8.1</maven.compiler.version>
       <license-tool-plugin-version>1.1.0</license-tool-plugin-version>
-      <tomcat.version>11.0.2</tomcat.version>
+      <tomcat.version>11.0.11</tomcat.version>
+      <spring-security.version>6.4.10</spring-security.version>
+      <spring-framework.version>6.2.11</spring-framework.version>
    </properties>
 
    <modules>
@@ -139,7 +142,33 @@
       <dependency>
          <groupId>org.springframework.security</groupId>
          <artifactId>spring-security-test</artifactId>
+         <version>${spring-security.version}</version>
          <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework.security</groupId>
+         <artifactId>spring-security-core</artifactId>
+         <version>${spring-security.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework</groupId>
+         <artifactId>spring-core</artifactId>
+         <version>${spring-framework.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework</groupId>
+         <artifactId>spring-context</artifactId>
+         <version>${spring-framework.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework</groupId>
+         <artifactId>spring-web</artifactId>
+         <version>${spring-framework.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework</groupId>
+         <artifactId>spring-webmvc</artifactId>
+         <version>${spring-framework.version}</version>
       </dependency>
       <dependency>
          <groupId>org.projectlombok</groupId>
@@ -212,6 +241,21 @@
          <groupId>org.openapitools</groupId>
          <artifactId>jackson-databind-nullable</artifactId>
          <version>${jackson-nullable.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-core</artifactId>
+         <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-databind</artifactId>
+         <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-annotations</artifactId>
+         <version>${jackson.version}</version>
       </dependency>
 
       <!-- Test -->


### PR DESCRIPTION
## Description

Fix CodeQL security alert [#110](https://github.com/Federity-X/public-sldt-discovery-finder/security/code-scanning/110) for disabled Spring CSRF protection.

### Changes:

• Migrate `OAuthConfig` and `LocalOAuthConfig` from deprecated chaining DSL to Spring Security 6 lambda DSL
• Replace `.csrf().disable()` with `.csrf(csrf -> csrf.ignoringRequestMatchers(new AntPathRequestMatcher("/api/**")))` so CSRF is only exempted for bearer-token-protected API paths
• Replace deprecated `.sessionManagement().sessionCreationPolicy(...).and()` with `.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))`
• Replace deprecated `.headers().frameOptions().disable().and()` with `.headers(headers -> headers.frameOptions(frame -> frame.disable()))` in `LocalOAuthConfig`

### Why CSRF is disabled for `/api/**`:

This is a stateless REST API secured with OAuth2 JWT bearer tokens (`SessionCreationPolicy.STATELESS`). CSRF attacks exploit automatic cookie-based authentication — since no HTTP sessions or cookies are used, CSRF protection is not applicable for API endpoints. CSRF remains active for all non-API paths.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files